### PR TITLE
Update SpecialManualSitemap.php

### DIFF
--- a/ManualSitemap/SpecialManualSitemap.php
+++ b/ManualSitemap/SpecialManualSitemap.php
@@ -65,7 +65,7 @@ class SpecialManualSitemap extends SpecialPage {
 	public function __construct() {
 		parent::__construct( 'ManualSitemap', 'manualsitemap', true );
 	}
-    function execute() {
+    function execute($subPage) {
         global $wgUser, $wgOut;
 
 		if ( ! $wgUser->isAllowed("manualsitemap") ) {

--- a/ManualSitemap/SpecialManualSitemap.php
+++ b/ManualSitemap/SpecialManualSitemap.php
@@ -140,7 +140,7 @@ class SpecialManualSitemap extends SpecialPage {
 
                 $info="";
 
-                if( $this->offset != 0 ) {
+                if( isset($this->offset) && $this->offset != 0 ) {
                         $class="errorbox";
                         $info="<strong>This selection misses the $this->offset most viewed pages of $wgSitename, however</strong>...<br />\n"; #English
                 } else {


### PR DESCRIPTION
I got the following message with mediawiki 1.23.3.
- Strict Standards:  Declaration of SpecialManualSitemap::execute() should be compatible with SpecialPage::execute($subPage)
- Notice:  Undefined property: SpecialManualSitemap::$offset
